### PR TITLE
Load state from localStorage on app init

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -263,7 +263,7 @@ export default {
             throw new Error("invalid transactions format");
           }
         }
-      } catch (e) {
+      } catch {
         console.warn(
           "Failed to parse transactions from localStorage. Resetting to default."
         );
@@ -280,7 +280,7 @@ export default {
             throw new Error(" Invalid categories format");
           }
         }
-      } catch (e) {
+      } catch {
         console.warn(
           "Failed to parse categories from localStorage. Resetting to default."
         );


### PR DESCRIPTION
## Description

Restore transactions and categories from localStorage on app initialization to persist application state between reloads.

## Related Issue

Closes #9 

## Changes

- Read transactions and categories from localStorage on app creation
- Use stored data instead of default values when available
- Fallback to initial defaults if data is missing or invalid
- Handle corrupted localStorage data with try/catch

## How to Test

1. Add or modify transactions and categories
2. Reload the page and verify data is restored
3. Clear or corrupt localStorage and reload the page
4. Confirm the app still works with default values

## Screenshots (optional)