### PR TITLE
Separate the transactions and categories lists into different tabs

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -103,6 +103,11 @@ import TransactionList from "./components/transactionlist/TransactionList.vue";
 import NewCategoryForm from "./components/newCategory/NewCategoryForm.vue";
 import CategoryList from "./components/newCategory/CategoryList.vue";
 
+const LS_DATA = {
+  transactions: "finance-transactions",
+  categories: "finance-categories",
+};
+
 export default {
   name: "App",
   components: {
@@ -281,7 +286,9 @@ export default {
       }
     },
   },
-
+  created() {
+    this.restoreFromLocalStorage();
+  },
   methods: {
     restoreFromLocalStorage() {
       try {


### PR DESCRIPTION
## Description

Split the app UI into two tabs (Transactions / Settings) so users see only relevant sections at a time.

## Related Issue

Closes #29

## Changes

- Added header with two tabs: Transactions and Settings
- Highlight active tab with underline styling
- Rendered TransactionForm + TransactionList only on Transactions tab
- Rendered NewCategoryForm + CategoryList only on Settings tab
- Set Transactions as the default active tab

## How to Test

1. Open the app and confirm Transactions tab is active by default
2. Switch between Transactions and Settings and verify only tab-related content is shown
3. Confirm active tab is underlined

## Screenshots (optional)