### PR TITLE
Add a confirmation action before removing transactions or categories

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -236,6 +236,7 @@ export default {
       const confirmDelete = window.confirm(
         "Are you sure you want to delete this category? You won’t be able to undo this action later."
       );
+      if (!confirmDelete) return;
       this.categoryOptions = this.categoryOptions.filter(
         (c) => c.value !== value
       );


### PR DESCRIPTION
## Description

Added confirmation prompt before deleting a transaction using the native `window.confirm` dialog.

## Related Issue

Closes #33

## Changes

- Triggered confirmation dialog on delete action
- Removed transaction only after user confirmation
- Prevented deletion when action is canceled

## How to Test

1. Click the delete button on a transaction
2. Confirm deletion in the dialog and verify the item is removed
3. Click cancel and verify the item remains

## Screenshots (optional)