### PR TITLE
Persist transactions and categories to localStorage

### DIFF
--- a/src/components/transactionlist/TransactionItem.vue
+++ b/src/components/transactionlist/TransactionItem.vue
@@ -36,7 +36,6 @@ export default {
   emits: ["delete", "edit"],
   components: { IconButton },
   props: {
-    id: { type: [String, Number], required: true },
     type: { type: String, required: true },
     amount: { type: Number, required: true },
     category: { type: String, required: true },

--- a/src/components/transactionlist/TransactionList.vue
+++ b/src/components/transactionlist/TransactionList.vue
@@ -6,7 +6,6 @@
       :key="transaction.id"
     >
       <TransactionItem
-        :id="transaction.id"
         :type="transaction.type"
         :amount="transaction.amount"
         :category="transaction.category"


### PR DESCRIPTION
## Description

Persist transactions and categories to localStorage on every change to keep application state between reloads.

## Related Issue

Closes #8

## Changes

- Added deep watchers for transactions and categories
- Save data to localStorage as JSON
- Use consistent storage keys:
  - finance-transactions
  - finance-categories

## How to Test

1. Add, edit, or delete a transaction or category
2. Open DevTools → Application → Local Storage and verify data is saved
3. Reload the page and confirm data persists

## Screenshots (optional)