### PR TITLE
replace Options API with Composition API; add provide/inject

### DIFF
--- a/src/components/views/SettingsView.vue
+++ b/src/components/views/SettingsView.vue
@@ -1,0 +1,71 @@
+<template>
+  <div class="settings">
+    <div>
+      <TheTypography variant="title">Settings</TheTypography>
+      <TheTypography variant="subtitle">
+        Manage your transaction categories
+      </TheTypography>
+    </div>
+
+    <NewCategoryForm
+      @submit="addNewCategory"
+      :transactionTypeOptions="transactionTypeOptions"
+    />
+
+    <div class="settings__categories-section">
+      <CategoryList
+        title="Income Categories"
+        subtitle="Manage income categories for your transactions"
+        :categoryOptions="incomeCategories"
+        @delete="deleteCategory"
+      />
+      <CategoryList
+        title="Expense Categories"
+        subtitle="Manage expense categories for your transactions"
+        :categoryOptions="expenseCategories"
+        @delete="deleteCategory"
+      />
+    </div>
+  </div>
+</template>
+
+<script>
+import { inject } from "vue";
+import TheTypography from "../TheTypography.vue";
+import NewCategoryForm from "../newCategory/NewCategoryForm.vue";
+import CategoryList from "../newCategory/CategoryList.vue";
+
+export default {
+  name: "SettingsView",
+  components: { TheTypography, NewCategoryForm, CategoryList },
+  setup() {
+    const addNewCategory = inject("addNewCategory");
+    const transactionTypeOptions = inject("transactionTypeOptions");
+    const incomeCategories = inject("incomeCategories");
+    const expenseCategories = inject("expenseCategories");
+    const deleteCategory = inject("deleteCategory");
+    return {
+      addNewCategory,
+      transactionTypeOptions,
+      incomeCategories,
+      expenseCategories,
+      deleteCategory,
+    };
+  },
+};
+</script>
+
+<style scoped>
+.settings {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+.settings__categories-section {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  max-width: 1420px;
+  min-width: 820px;
+}
+</style>

--- a/src/components/views/TransactionsView.vue
+++ b/src/components/views/TransactionsView.vue
@@ -1,0 +1,98 @@
+<template>
+  <div class="transactions">
+    <div>
+      <TheTypography variant="title">Transactions</TheTypography>
+      <TheTypography variant="subtitle">
+        Add, edit, or manage your transactions
+      </TheTypography>
+    </div>
+
+    <div class="transactions__content">
+      <TransactionForm
+        :title="transactionFormTitle"
+        @submit="saveNewTransaction"
+        @update="saveUpdateTransaction"
+        @cancel="editingTransaction = null"
+        :editingValues="editingTransaction"
+        :categoryOptions="categoryOptions"
+        :transactionTypeOptions="transactionTypeOptions"
+      />
+
+      <TransactionListSection
+        :categoryOptions="categoryOptionsByTypeWithAll"
+        :transactionTypeOptions="transactionTypeOptionsWithAll"
+        title="Transaction List"
+        subtitle="Manage and filter your transactions"
+        v-model:transactionType="filterModel.transactionType"
+        v-model:transactionCategory="filterModel.category"
+      >
+        <TransactionList
+          :transactions="filteredTransactions"
+          @delete="deleteTransaction"
+          @edit="editingTransaction = $event"
+        />
+      </TransactionListSection>
+    </div>
+  </div>
+</template>
+
+<script>
+import { inject } from "vue";
+import TransactionForm from "@/components/TransactionForm.vue";
+import TransactionListSection from "@/components/transactionlist/TransactionListSection.vue";
+import TransactionList from "@/components/transactionlist/TransactionList.vue";
+import TheTypography from "@/components/TheTypography.vue";
+
+export default {
+  name: "TransactionsView",
+  components: {
+    TransactionForm,
+    TransactionListSection,
+    TransactionList,
+    TheTypography,
+  },
+
+  setup() {
+    const transactionFormTitle = inject("transactionFormTitle");
+    const saveNewTransaction = inject("saveNewTransaction");
+    const saveUpdateTransaction = inject("saveUpdateTransaction");
+    const editingTransaction = inject("editingTransaction");
+    const categoryOptions = inject("categoryOptions");
+    const transactionTypeOptions = inject("transactionTypeOptions");
+    const categoryOptionsByTypeWithAll = inject("categoryOptionsByTypeWithAll");
+    const transactionTypeOptionsWithAll = inject(
+      "transactionTypeOptionsWithAll",
+    );
+    const filterModel = inject("filterModel");
+    const filteredTransactions = inject("filteredTransactions");
+    const deleteTransaction = inject("deleteTransaction");
+
+    return {
+      transactionFormTitle,
+      saveNewTransaction,
+      saveUpdateTransaction,
+      editingTransaction,
+      categoryOptions,
+      transactionTypeOptions,
+      categoryOptionsByTypeWithAll,
+      transactionTypeOptionsWithAll,
+      filterModel,
+      filteredTransactions,
+      deleteTransaction,
+    };
+  },
+};
+</script>
+
+<style scoped>
+.transactions {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.transactions__content {
+  display: flex;
+  gap: 20px;
+}
+</style>


### PR DESCRIPTION
## Description

Refactored components from Options API to Composition API and introduced provide/inject for shared state and actions between App and child views.

## Related Issue

Closes #49


## Changes

Replaced Options API with Composition API in core components

Moved shared state and logic to App.vue using provide

Connected child components via inject


## How to Test

1. Run the app

2. Switch between Transactions and Settings tabs

3. Add, edit, delete transactions

4. Add and delete categories


## Screenshots (optional)
